### PR TITLE
fix: :bulb: commented articles via api down

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,11 +128,11 @@ const HomePage = () => {
             </Group>
           </Paper>
         </Group>
-        {data && (
+        {data.items?.length && (
           <Group direction="column" mt={60}>
             <Title order={2}>Latest Articles</Title>
             <Stack spacing="xs">
-              {data.items.slice(0, 6).map((article: IArticleProps) => (
+              {data.items?.slice(0, 6).map((article: IArticleProps) => (
                 <Text
                   key={article.title}
                   component="a"

--- a/src/routes/navigation.ts
+++ b/src/routes/navigation.ts
@@ -9,10 +9,10 @@ export const navigation = [
     link: urls.Projects,
     label: 'Projects',
   },
-  {
-    link: urls.Articles,
-    label: 'Articles',
-  },
+  // {
+  //   link: urls.Articles,
+  //   label: 'Articles',
+  // },
   {
     link: urls.Bookmarks,
     label: 'Bookmarks',


### PR DESCRIPTION
Remove `Articles` pages from navigation. (rss4json api down)